### PR TITLE
Add `repository` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "knockout-undoredo",
   "version": "1.0.3",
   "description": "A multi-purpose undo/redo manger for knockout",
+  "repository": "krnlde/knockout-undoredo",
   "main": "dist/knockout-undoredo.min.js",
   "scripts": {
     "test": "mocha --require babel-register"


### PR DESCRIPTION
This way the corresponding [npm info page](https://www.npmjs.com/package/knockout-undoredo) shows links to the Github repo and issues page :octocat: